### PR TITLE
Limit spanner backup google_cloudfunctions_function max instances to 1

### DIFF
--- a/proj-tf-spanner-backups/modules/backup-scheduler/main.tf
+++ b/proj-tf-spanner-backups/modules/backup-scheduler/main.tf
@@ -85,6 +85,7 @@ resource "google_cloudfunctions_function" "spanner_backup_function" {
     event_type = "google.pubsub.topic.publish"
     resource   = google_pubsub_topic.backup_topic[each.value].id
   }
+  max_instances = 1
   source_archive_bucket = google_storage_bucket.bucket_gcf_source.name
   source_archive_object = google_storage_bucket_object.gcs_functions_backup_source.name
   service_account_email = google_service_account.backup_sa.email


### PR DESCRIPTION
This PR addresses to things by setting `google_cloudfunctions_function.max_instances`:
1. it doesn't make sense to have more then one instance of the backup function 
2. Terraform detects remote state changes because GCP sets max_instances to 3000 internally and every deployment Terraform reports it as a remote change and sets it to "0"